### PR TITLE
Move build status markdown to new line

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# blank-ios-app [![Build Status](https://travis-ci.org/feedhenry-templates/blank-ios-app.png)](https://travis-ci.org/feedhenry-templates/blank-ios-app)
+# blank-ios-app
+[![Build Status](https://travis-ci.org/feedhenry-templates/blank-ios-app.png)](https://travis-ci.org/feedhenry-templates/blank-ios-app)
 
 > Swift version of Blank iOS app is available [here](https://github.com/feedhenry-templates/blank-ios-app/tree/swift).
 > ObjC/CocoaPods of  Blank iOS app is available [here](https://github.com/feedhenry-templates/blank-ios-app/tree/cocoapods).


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/FH-3422

Motivation: Studio cannot convert the markdown if it's on the same line as the header